### PR TITLE
Add npm badge

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+/.eslintignore
+/.eslintrc.json

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# codemirror-mode-zenscript
+codemirror-mode-zenscript
+==============
+[![npm version](https://badge.fury.io/js/codemirror-mode-zenscript.svg)](https://badge.fury.io/js/codemirror-mode-zenscript)
+[![dependencies Status](https://david-dm.org/CraftTweaker/codemirror-mode-zenscript/status.svg)](https://david-dm.org/CraftTweaker/codemirror-mode-zenscript)
+
 > A CodeMirror mode for [ZenScript](https://github.com/CraftTweaker/ZenScript)
 
 ## Installation


### PR DESCRIPTION
This is a less exciting PR than the last, but adds an npm & dependencies badge to the README, as well as an .npmignore file so to not publish unnecessary files. Minor things, but nice to have for open-source JS.