### PR TITLE
Fix bundle compressing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "codemirror-mode-zenscript",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codemirror-mode-zenscript",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "A CodeMirror mode for the ZenScript language",
   "keywords": [
     "codemirror",
@@ -22,10 +22,10 @@
   "module": "dist/codemirror-mode-zenscript.mjs",
   "source": "index.js",
   "scripts": {
-    "build": "microbundle build --compress false",
+    "build": "microbundle build --no-compress",
     "lint": "eslint . --fix",
     "test": "npm run lint",
-    "watch": "microbundle watch --compress false"
+    "watch": "microbundle watch --no-compress"
   },
   "devDependencies": {
     "codemirror": "^5.46.0",


### PR DESCRIPTION
I typo'd the previous build args. It should be `--no-compress` so to prevent the import statements from being mangled. The current builds work, but can trigger errors in various environments - we've seen a few of those since the rollout.

I already bumped the version, so this should be good to build and then publish. Thanks!